### PR TITLE
feat: support label/device/area exclusions in battery detection blueprint

### DIFF
--- a/low-battery-level-detection-notification-for-all-battery-sensors.yaml
+++ b/low-battery-level-detection-notification-for-all-battery-sensors.yaml
@@ -54,13 +54,24 @@ variables:
   day: !input 'day'
   threshold: !input 'threshold'
   exclude: !input 'exclude'
+  exclude_entities: >
+    {%- set ns = namespace(ret=[]) %}
+    {%- for key in ['device', 'area', 'entity', 'label'] %}
+      {%- set items = exclude.get(key ~ '_id', [])  %}
+      {%- if items %}
+        {%- set items = [ items ] if items is string else items %}
+        {%- set items = items if key == 'entity' else items | map(key ~ '_entities') | sum(start=[]) %}
+        {%- set ns.ret = ns.ret + [ items ] %}
+      {%- endif %}
+    {%- endfor %}
+    {{ ns.ret | sum(start=[]) }}
   sensors: >
     {% set result = namespace(sensors=[]) %} 
     {% for state in states.sensor
       | rejectattr('attributes.device_class', 'undefined')
       | selectattr('attributes.device_class', '==', 'battery') %} 
       {% if 0 <= state.state | int(-1) < threshold | int 
-        and not state.entity_id in exclude.entity_id
+        and not state.entity_id in exclude_entities
         and state.entity_id not in integration_entities("mobile_app") %}
         {% set result.sensors = result.sensors + [state.name ~ ' (' ~ state.state ~ '%)'] %}
       {% endif %}
@@ -69,7 +80,7 @@ variables:
       | rejectattr('attributes.device_class', 'undefined')
       | selectattr('attributes.device_class', '==', 'battery')
       | selectattr('state', '==', 'on') %}
-      {% if not state.entity_id in exclude.entity_id %}
+      {% if not state.entity_id in exclude_entities %}
         {% set result.sensors = result.sensors + [state.name] %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
## Summary

- Extends the `exclude` input to resolve all four selector types (device, area, entity, label) into a flat entity list before filtering
- Previously only `entity_id` exclusions worked; device, area, and label selectors were silently ignored
- Adds `exclude_entities` template variable that expands all selector types via `*_entities` lookups

## Test plan

- [ ] Verify excluded entities via label are skipped in the battery notification
- [ ] Verify existing entity-based exclusions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)