### PR TITLE
fix: select turn-off entities per-domain (not via device_class area discovery)

### DIFF
--- a/turn-off-everything-except.yaml
+++ b/turn-off-everything-except.yaml
@@ -48,7 +48,6 @@ blueprint:
 mode: single
 max_exceeded: silent
 variables:
-  state: 'on'
   debug_mode: !input debug_mode
   exclude_labels: !input exclude_labels
   # Entities to keep on: directly labelled entities plus every entity that
@@ -62,40 +61,24 @@ variables:
       {% endfor %}
     {% endfor %}
     {{ ns.entities | unique | list }}
-  areas: >
-    {% set areas = states
-      | selectattr('attributes.device_class', 'defined')
-      | map(attribute='entity_id')
-      | map('area_id') | unique | reject('none') | list %}
-    {{ areas | list }}
+  # Select directly from each domain's states: this covers every area AND
+  # entities without an area, and doesn't depend on entities exposing a
+  # device_class (the old area-from-device_class derivation skipped areas that
+  # only held plain lights/switches).
   lights: >
-    {% set ns = namespace(entities=[]) %}
-    {% for area in areas %}
-      {% set ns.entities = ns.entities + expand(area_entities(area) | select('match', 'light'))
-        | selectattr('state', 'eq', state) | map(attribute='entity_id') | list %}
-    {% endfor %}
-    {{ ns.entities | reject('in', excluded_entities) | list }}
+    {{ states.light | selectattr('state', 'eq', 'on')
+       | map(attribute='entity_id') | reject('in', excluded_entities) | list }}
   switches: >
-    {% set ns = namespace(entities=[]) %}
-    {% for area in areas %}
-      {% set ns.entities = ns.entities + expand(area_entities(area) | select('match', 'switch'))
-        | selectattr('state', 'eq', state) | map(attribute='entity_id') | list %}
-    {% endfor %}
-    {{ ns.entities | reject('in', excluded_entities) | list }}
+    {{ states.switch | selectattr('state', 'eq', 'on')
+       | map(attribute='entity_id') | reject('in', excluded_entities) | list }}
   media_players: >
-    {% set ns = namespace(entities=[]) %}
-    {% for area in areas %}
-      {% set ns.entities = ns.entities + expand(area_entities(area) | select('match', 'media_player'))
-        | selectattr('state', 'eq', state) | map(attribute='entity_id') | list %}
-    {% endfor %}
-    {{ ns.entities | reject('in', excluded_entities) | list }}
+    {{ states.media_player
+       | rejectattr('state', 'in', ['off', 'unavailable', 'unknown', 'standby', 'idle'])
+       | map(attribute='entity_id') | reject('in', excluded_entities) | list }}
   climate: >
-    {% set ns = namespace(entities=[]) %}
-    {% for area in areas %}
-      {% set ns.entities = ns.entities + expand(area_entities(area) | select('match', 'climate'))
-        | selectattr('state', 'ne', 'off') | map(attribute='entity_id') | list %}
-    {% endfor %}
-    {{ ns.entities | reject('in', excluded_entities) | list }}
+    {{ states.climate
+       | rejectattr('state', 'in', ['off', 'unavailable', 'unknown'])
+       | map(attribute='entity_id') | reject('in', excluded_entities) | list }}
 trigger:
   - platform: time
     at: !input trigger_time


### PR DESCRIPTION
## Problem
`turn-off-everything-except.yaml` discovered areas from entities that expose a
`device_class`, then iterated `area_entities(area)`. Consequences:
- areas containing **only** plain lights/switches (no `device_class` entity) were
  **skipped**, so those devices never turned off;
- entities **without an area** were never considered.

## Fix
Select directly from each domain's states — `states.light` / `states.switch` /
`states.media_player` / `states.climate` — filtered by state and minus the excluded
(`dontturnoff`) entities. This covers **every** area and area-less entities, drops the
`device_class` dependency, and is simpler (the `areas` and `state` variables are gone).

`excluded_entities` (the `dontturnoff` label expansion) and `debug_mode` are unchanged.

## Testing
Logic simulated (jinja2): lights/switches only when `on`; media players excluding
`off/unavailable/unknown/standby/idle`; climate excluding `off/unavailable/unknown`;
all minus excluded entities — returns exactly the expected sets.

## Follow-up
The `home-assistant-config` repo pins this blueprint as a submodule, so after merge
its submodule pointer needs bumping (`git submodule update --remote` + commit) to pick
this up — I can open that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)